### PR TITLE
Fixes for media files upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@
 $ pip install -r requirements/dev.txt
 ```
 ## Setup and Run
+Set system locale to utf8
+```sh
+export LC_ALL='en_US.utf8'
+```
 ### Develop: Use local settings file
 Define your own `local_settings.py` under `settings/`
 #### Runserver
@@ -53,7 +57,10 @@ uwsgi --ini server-settings/smart_campus.ini
 ```sh
 sudo killall -s INT uwsgi
 ```
-
+##### View log
+```sh
+sudo tail -f /var/log/smartcampus/smartcampus.log
+```
 ## Testing
 
 ### Run Test

--- a/server-settings/nginx.conf
+++ b/server-settings/nginx.conf
@@ -16,7 +16,7 @@ server {
 
     # Django media
     location /media  {
-                alias /home/rapirent/smart_campus/smart_campus/smart_campus/media;      # your Django project's media files
+                alias /var/www/smartcampus.csie.ncku.edu.tw/media;      # your Django project's media files
     	}
 
     location /static {

--- a/server-settings/smart_campus.ini
+++ b/server-settings/smart_campus.ini
@@ -14,3 +14,4 @@ module          = %(project).wsgi
 home            = %(base)/smart_campus/venv/
 
 vacuum          = true
+daemonize       = /var/log/smartcampus/smartcampus.log

--- a/smart_campus/app/views.py
+++ b/smart_campus/app/views.py
@@ -13,7 +13,7 @@ from django.contrib.auth.decorators import login_required
 from django.contrib import messages
 from django.contrib.gis.geos import Point
 from django.conf import settings
-from django.core.files.uploadedfile import InMemoryUploadedFile
+from django.core.files.uploadedfile import UploadedFile
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from django.db import IntegrityError
 from django.core import serializers
@@ -180,6 +180,7 @@ def index(request):
 
 
 @login_required
+@csrf_exempt
 def station_list_page(request):
     if request.user.can(Permission.ADMIN):
         station_list = Station.objects.all().order_by('id')
@@ -275,7 +276,7 @@ def station_edit_page(request, pk):
 
             # Add new images
             for key, value in data.items():
-                if isinstance(value, InMemoryUploadedFile):
+                if isinstance(value, UploadedFile):
                     StationImage.objects.create(
                         station=station,
                         image=value,
@@ -377,7 +378,7 @@ def station_new_page(request):
 
             # Add images
             for key, value in data.items():
-                if isinstance(value, InMemoryUploadedFile):
+                if isinstance(value, UploadedFile):
                     is_primary = (key == 'img{0}'.format(data['main_img_num']))
                     StationImage.objects.create(
                         station=station,

--- a/smart_campus/smart_campus/settings/production.py
+++ b/smart_campus/smart_campus/settings/production.py
@@ -16,3 +16,5 @@ DATABASES = {
         'PORT':  get_env_variable('POSTGRESQL_PORT'),
     },
 }
+
+MEDIA_ROOT = '/var/www/smartcampus.csie.ncku.edu.tw/media'


### PR DESCRIPTION
1. Change MEDIA_ROOT to ```/var/www/smartcampus.csie.ncku.edu.tw/media``` in production.
2. Change InMemoryUploadedFile to UploadedFile in views.py. The uploaded images are not always of InMemoryUploadedFile instance type, causing errors sometimes.
3. Add system locale settings
4. Add log of uwsgi
