### PR TITLE
Modify the response in API get_unanswered_question

### DIFF
--- a/smart_campus/app/views.py
+++ b/smart_campus/app/views.py
@@ -1393,7 +1393,7 @@ def get_unanswered_question(request):
     ).filter(linked_station=station)
 
     if not unanswered_questions:
-        return HttpResponse('No unanswered question available for the user', status=404)
+        return JsonResponse(data={}, status=200)
 
     random_index = random.randint(0, unanswered_questions.count() - 1)
     random_unanswered_question = random.sample(list(unanswered_questions), 1)[0]


### PR DESCRIPTION
API get_unanswered_question FIX:

For frontend design convenience,
when there's no more question available,
respond status 200 with a empty json object instead of status 404